### PR TITLE
Added support for IgnoreSslErrors toggle to ThreadedUrlMonitor.java

### DIFF
--- a/src/main/java/com/appdynamics/extensions/urlmonitor/ThreadedUrlMonitor.java
+++ b/src/main/java/com/appdynamics/extensions/urlmonitor/ThreadedUrlMonitor.java
@@ -45,6 +45,7 @@ public class ThreadedUrlMonitor extends AManagedMonitor {
         AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
 
         builder.setFollowRedirect(clientConfig.isFollowRedirects())
+                .setIgnoreSslErrors(clientConfig.isIgnoreSslErrors())
                 .setMaxRedirects(clientConfig.getMaxRedirects())
                 .setConnectTimeout(defaultSiteConfig.getConnectTimeout())
                 .setRequestTimeout(defaultSiteConfig.getSocketTimeout())

--- a/src/main/java/com/appdynamics/extensions/urlmonitor/ThreadedUrlMonitor.java
+++ b/src/main/java/com/appdynamics/extensions/urlmonitor/ThreadedUrlMonitor.java
@@ -45,7 +45,7 @@ public class ThreadedUrlMonitor extends AManagedMonitor {
         AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
 
         builder.setFollowRedirect(clientConfig.isFollowRedirects())
-                .setIgnoreSslErrors(clientConfig.isIgnoreSslErrors())
+                .setAcceptAnyCertificate(clientConfig.isIgnoreSslErrors())
                 .setMaxRedirects(clientConfig.getMaxRedirects())
                 .setConnectTimeout(defaultSiteConfig.getConnectTimeout())
                 .setRequestTimeout(defaultSiteConfig.getSocketTimeout())


### PR DESCRIPTION
This references Request #68310.

It does not appear that the value set by the ignoreSslErrors toggle in the client config is actually being used by the code, at least as far as configuring the client.  

I've added code similar to the followRedirects toggle, but have not been able to test the code.
